### PR TITLE
[PKG-3564] v1.1.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+  - https://staging.continuum.io/prefect/fs/gdown-feedstock/pr2/57d94c4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/prefect/fs/gdown-feedstock/pr2/57d94c4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: dab68723994c6b4503f20f543dad80a1a2177791520115313a80a6d1167e69a4
 
 build:
-  noarch: python
-  number: 1
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<36]
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-build-isolation --no-deps -vv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,10 @@ test:
 
 about:
   home: https://github.com/makcedward/nlpaug
+  dev_url: https://github.com/makcedward/nlpaug
+  doc_url: https://github.com/makcedward/nlpaug/tree/master/docs
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Natrual language processing data Augmentation library
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - gdown >=4.0.0
-    - numpy
+    - numpy >=1.16.2
     - pandas >=1.2.0
     - requests >=2.22.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,15 +21,11 @@ requirements:
     - setuptools
     - wheel
   run:
-    - datasets >=1.8.0
+    - python
     - gdown >=4.0.0
-    - numpy >=1.16.2
-    - pandas
-    - python >=3.6
-    - pytorch >=1.2.0
+    - numpy
+    - pandas >=1.2.0
     - requests >=2.22.0
-    - sentencepiece
-    - transformers
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,8 +16,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
     - datasets >=1.8.0
     - gdown >=4.0.0


### PR DESCRIPTION
[PKG-3564](https://anaconda.atlassian.net/browse/PKG-3564)
[Upstream repo](https://github.com/makcedward/nlpaug/tree/1.1.11)

Target channel: Snowflake ❄️

`nlpaug` -> `autogluon`

Leaving out upstream tests as they would take multiple hours to run for each Python version and have undeclared dependencies.

[PKG-3564]: https://anaconda.atlassian.net/browse/PKG-3564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ